### PR TITLE
Use WinActivate after restoring

### DIFF
--- a/quake-windows-bash.ahk
+++ b/quake-windows-bash.ahk
@@ -14,6 +14,7 @@ BashHandle = ahk_exe bash.exe
     if (mx = -1)
     {
         WinRestore, %BashHandle%
+        WinActivate, %BashHandle%
 
         ; Uncomment these lines to overcome tmux/vim rendering bug
         ; ControlSend, , ^{VK42}, %BashHandle%


### PR DESCRIPTION
Use WinActivate to activate window after restoring, in case user is using another window handler (xorg on windows).

I'm using VcXsrv (and a real console from linux), and after using WinRestore it wont focus the window. Haven't tried on normal bash.exe / ubuntu.exe